### PR TITLE
remove package.json and package-lock.json from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,4 @@
 .idea/modules.xml
 .idea/vcs.xml
 .idea/workspace.xml
-app/package-lock.json
-app/package-lock.json
-app/package.json
 app/src/environments/


### PR DESCRIPTION
I'm not sure how these files came to be ignored, but they shouldn't be.

Also, these files _are_ present in the repo, so it's possible these lines were added to `.gitignore` _after_ those files were added to the repo, and it's possible that their presence in this file has had or will have had an ongoing, adverse effect on keeping those files up to date.

At any rate, this sets things straight.