### PR TITLE
fix topo-pattern-white.png path in styles.scss

### DIFF
--- a/app/src/styles.scss
+++ b/app/src/styles.scss
@@ -25,7 +25,7 @@ $nunito-font-path: 'assets/fonts' !default;
 body {
   font-size: 16px;
   font-family: $nunito;
-  background: url("../../../kashti/app/src/assets/images/topo-pattern-white.png") repeat 20px 0, linear-gradient(185deg, #F0F1F6 0%, #e9ecf2 100%);
+  background: url("assets/images/topo-pattern-white.png") repeat 20px 0, linear-gradient(185deg, #F0F1F6 0%, #e9ecf2 100%);
   background-size: auto auto, auto auto;
   background-size: 376px auto, auto auto;
   overflow-x: hidden;


### PR DESCRIPTION
The path to `topo-pattern-white.png` in this file is problematic. It backs up three levels (`../../../`) and then drills back down to the level it started at. It works... but only if you cloned the repo with the name `kashti`.

Supposing someone used a command such as `git clone <url> new-kashti` when cloning the repo, or supposing this code is mounted to a different path within a container in the course of producing a Docker image, then backing up three levels and drilling back down doesn't work.

Plus `assets/images/topo-pattern-white.png` is more clear and concise to begin with.

Note this is a necessary fix to avoid difficulties packaging this app as a Docker image.