### PR TITLE
add some hacking goodies

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -1,0 +1,99 @@
+SHELL ?= /bin/bash
+
+.DEFAULT_GOAL := build
+
+################################################################################
+# Version details                                                              #
+################################################################################
+
+# This will reliably return the short SHA1 of HEAD or, if the working directory
+# is dirty, will return that + "-dirty"
+GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty --match=NeVeRmAtCh)
+
+################################################################################
+# Containerized development environment-- or lack thereof                      #
+################################################################################
+
+ifneq ($(SKIP_DOCKER),true)
+	PROJECT_ROOT := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
+
+	KANIKO_IMAGE := brigadecore/kaniko:v0.2.0
+
+	KANIKO_DOCKER_CMD := docker run \
+		-it \
+		--rm \
+		-e SKIP_DOCKER=true \
+		-e DOCKER_PASSWORD=$${DOCKER_PASSWORD} \
+		-v $(PROJECT_ROOT):/workspaces/kashti \
+		-w /workspaces/kashti \
+		$(KANIKO_IMAGE)
+endif
+
+################################################################################
+# Docker images we build and publish                                           #
+################################################################################
+
+ifdef DOCKER_REGISTRY
+	DOCKER_REGISTRY := $(DOCKER_REGISTRY)/
+endif
+
+ifdef DOCKER_ORG
+	DOCKER_ORG := $(DOCKER_ORG)/
+endif
+
+DOCKER_IMAGE_NAME := $(DOCKER_REGISTRY)$(DOCKER_ORG)kashti
+
+ifdef VERSION
+	MUTABLE_DOCKER_TAG := latest
+else
+	VERSION            := $(GIT_VERSION)
+	MUTABLE_DOCKER_TAG := edge
+endif
+
+IMMUTABLE_DOCKER_TAG := $(VERSION)
+
+################################################################################
+# Build                                                                        #
+################################################################################
+
+.PHONY: build
+build:
+	$(KANIKO_DOCKER_CMD) kaniko \
+		--context dir:///workspaces/kashti/ \
+		--no-push
+
+################################################################################
+# Publish                                                                      #
+################################################################################
+
+.PHONY: publish
+publish:
+	$(KANIKO_DOCKER_CMD) sh -c ' \
+		docker login $(DOCKER_REGISTRY) -u $(DOCKER_USERNAME) -p $${DOCKER_PASSWORD} && \
+		kaniko \
+			--dockerfile /workspaces/kashti/Dockerfile \
+			--context dir:///workspaces/kashti/ \
+			--destination $(DOCKER_IMAGE_NAME)$*:$(IMMUTABLE_DOCKER_TAG) \
+			--destination $(DOCKER_IMAGE_NAME)$*:$(MUTABLE_DOCKER_TAG) \
+	'
+
+################################################################################
+# Targets to facilitate hacking on Kashti.                                     #
+################################################################################
+
+.PHONY: hack-build
+hack-build:
+	docker build \
+		-t $(DOCKER_IMAGE_NAME)$*:$(IMMUTABLE_DOCKER_TAG) \
+		.
+
+hack-run: hack-build
+	docker run \
+		-it \
+		-v $(PROJECT_ROOT)/hack/api-reverse-proxy.nginx.conf:/etc/nginx/kashti.conf.d/api-reverse-proxy.conf \
+		-p 8080:80 \
+		$(DOCKER_IMAGE_NAME)$*:$(IMMUTABLE_DOCKER_TAG)
+
+.PHONY: hack-push
+hack-push: hack-build
+	docker push $(DOCKER_IMAGE_NAME)$*:$(IMMUTABLE_DOCKER_TAG)

--- a/app/hack/api-reverse-proxy.nginx.conf
+++ b/app/hack/api-reverse-proxy.nginx.conf
@@ -1,0 +1,3 @@
+location /v2/ {
+    proxy_pass https://brigade2.byu.kashti.sh/v2/;
+}


### PR DESCRIPTION
This should only be merged after #8.

This PR adds, for convenience, some make targets that can build and publish a Docker image of Kashti two different ways:

1. Using kaniko-- this is a good way of building a Docker image whilst _inside_ another Docker container without encountering a complex "Docker in Docker" scenario. Eventually, this will be useful for building/publishing from within CI/CD processes, which, themselves, tend to occur within containers.

2. Using traditional methods. This is _faster_, so it's more ideal when one is just hacking/experimenting locally and there's no "Docker in Docker" scenario to avoid.

For the ultimate convenience, `make run` will build a Docker image of Kashti and launch a new container based on that image. It also mounts some reverse proxy configuration for the Brigade 2 API server into the container. This isn't intended to replace anyone's existing workflow, but it's a good validation of our strategy of using reverse proxy configuration that is provided at install-time as a means of making sure any instance of Kashti can talk to the correct Brigade 2 API server at runtime.

Much of this will be revisited when the Kubernetes packaging (Helm chart) is PR'ed.